### PR TITLE
Prevent problems with "Value" variable in code

### DIFF
--- a/include/etest_http.hrl
+++ b/include/etest_http.hrl
@@ -175,7 +175,7 @@ end)(Value0, Res))).
                             [{json_struct, __JsonStruct},
                              {module, ?MODULE},
                              {line,   ?LINE}] });
-            Value -> Value
+            __JsonValue -> __JsonValue
         end;
 
     (__Key, __Res) ->
@@ -184,7 +184,7 @@ end)(Value0, Res))).
             undefined -> erlang:error({json_val_undefined,
                             [{module, ?MODULE},
                              {line,   ?LINE}] });
-            Value -> Value
+            __JsonValue -> __JsonValue
         end
  end)(__Key, __Response))).
 


### PR DESCRIPTION
Such code could lead to hard-to-find problem:

```
Value = 10, %% this will lead to {error, case_clause} 
?get_json_value(<<"key">>, Json).
```

`Value` is widely used variable name in code. `__JsonValue` is not.
