### PR TITLE
Content type fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,8 +8,10 @@
     % For testing etest_http itself.
     {etest, ".*", {git, "git://github.com/wooga/etest.git", "HEAD"}},
     % For JSON encoding, decoding and subsequently comparison.
-    {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "HEAD"}}
+    {jiffy, ".*", {git, "git://github.com/davisp/jiffy.git", "HEAD"}},
+    % For mocking httpc.
+    {meck, ".*", {git, "git://github.com/eproxus/meck.git", "HEAD"}}
 ]}.
 
-{clean_files, ["ebin/*.beam"]}.
+{clean_files, ["ebin/*.beam", ".eunit/*"]}.
 {xref_checks, [exports_not_used, undefined_function_calls]}.

--- a/test/etest_http_test.erl
+++ b/test/etest_http_test.erl
@@ -69,10 +69,10 @@ post_with_string_content_type_test() ->
     meck:expect(httpc, request, fun(post, {_, _, Type, _}, _, []) when Type == ContentType ->
                                         {ok, {{a,b,c},d,e}};
                                    (_, {_ , _, _, _}, _, _) ->
-                                        {error, bad_type}
+                                        {error, bad_header}
                                 end),
     URL = "http:localhost:8888/index.html",
-    Headers = [{"content-type", ContentType}],
+    Headers = [{"Content-Type", ContentType}],
     Body = <<"{\"name\":\"value\"}">>,
     ?assertMatch(#etest_http_res{}, etest_http:perform_request(post, URL, Headers, [], Body)),
     meck:unload(httpc).
@@ -83,10 +83,10 @@ post_with_binary_content_type_test() ->
     meck:expect(httpc, request, fun(post, {_, _, Type, _}, _, []) when Type == ContentType ->
                                         {ok, {{a,b,c},d,e}};
                                    (_, _, _, _) ->
-                                        {error, bad_type}
+                                        {error, bad_header}
                                 end),
     URL = "http:localhost:8888/index.html",
-    Headers = [{<<"content-type">>, ContentType}],
+    Headers = [{<<"Content-Type">>, ContentType}],
     Body = <<"{\"name\":\"value\"}">>,
     ?assertMatch(#etest_http_res{}, etest_http:perform_request(post, URL, Headers, [], Body)),
     meck:unload(httpc).

--- a/test/etest_http_test.erl
+++ b/test/etest_http_test.erl
@@ -5,7 +5,6 @@
 
 -include_lib("etest/include/etest.hrl").
 -include_lib("etest_http/include/etest_http.hrl").
--include_lib("eunit/include/eunit.hrl").
 
 before_suite() ->
     inets:start(),
@@ -61,6 +60,9 @@ test_json_assertions() ->
     ?assert_error({assert_json_val, _},
                   ?assert_json_value(<<"foo">>, undefined, Res)).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
 post_with_string_content_type_test() ->
     ContentType = "application/foo",
     meck:new(httpc),
@@ -89,4 +91,4 @@ post_with_binary_content_type_test() ->
     ?assertMatch(#etest_http_res{}, etest_http:perform_request(post, URL, Headers, [], Body)),
     meck:unload(httpc).
     
-    
+-endif.

--- a/test/etest_http_test.erl
+++ b/test/etest_http_test.erl
@@ -1,20 +1,22 @@
 %% @author Johannes Huning <johannes.huning@wooga.com>
 %% @doc Test of the assertions itself.
--module (etest_http_test).
--compile (export_all).
+-module(etest_http_test).
+-compile(export_all).
 
--include_lib ("etest/include/etest.hrl").
--include_lib ("etest_http/include/etest_http.hrl").
-
+-include_lib("etest/include/etest.hrl").
+-include_lib("etest_http/include/etest_http.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 before_suite() ->
     inets:start(),
-    {ok, Pid} = inets:start(httpd, [
-        {port, 59408},
-        {server_name,   "etest_httpd"},
-        {server_root,   "/tmp"},
-        {ipfamily,      inet},
-        {document_root, "priv"} ]),
+    {ok, Pid} = inets:start(httpd, 
+                            [
+                             {port, 59408},
+                             {server_name,   "etest_httpd"},
+                             {server_root,   "/tmp"},
+                             {ipfamily,      inet},
+                             {document_root, "priv"} 
+                            ]),
     put(server_pid, Pid).
 
 
@@ -24,37 +26,67 @@ after_suite() ->
 
 test_response_assertions() ->
     Res = ?perform_get("http://localhost:59408/first.html"),
-
+    
     ?assert_status(200, Res),
     ?assert_error({assert_status, _}, ?assert_status(400, Res)),
     ?assert_body_contains("Hello", Res),
     ?assert_body_not_contains("Olleh", Res),
-
+    
     ?assert_error({assert_contains, _}, ?assert_body_contains("Olleh", Res)),
-
+    
     ?assert_header("date", Res),
     ?assert_error({assert_header, _}, ?assert_header("X-Missing", Res)),
-
+    
     ?assert_header_value("content-type", "text/html", Res),
     ?assert_error({assert_header_val, _},
-        ?assert_header_value("content-type", "application/json", Res)).
+                  ?assert_header_value("content-type", "application/json", Res)).
 
 
 test_json_assertions() ->
     JsonStruct = etest_http_json:construct([
-        {foo, [bar, baz, 1, 2, 3]},
-        {bar, [{baz, bang}]}
-    ]),
+                                            {foo, [bar, baz, 1, 2, 3]},
+                                            {bar, [{baz, bang}]}
+                                           ]),
 
     Res = ?perform_get("http://localhost:59408/second.json"),
-
+    
     ?assert_json(JsonStruct, Res),
     ?assert_error({assert_equal, _}, ?assert_json([], Res)),
-
+    
     ?assert_json_key(<<"foo">>, Res),
     ?assert_error({assert_json_key, _}, ?assert_json_key("baz", Res)),
-
+    
     ?assert_json_value(<<"foo">>, [<<"bar">>, <<"baz">>, 1, 2, 3], Res),
     ?assert_json_value([<<"bar">>, <<"baz">>], <<"bang">>, Res),
     ?assert_error({assert_json_val, _},
-        ?assert_json_value(<<"foo">>, undefined, Res)).
+                  ?assert_json_value(<<"foo">>, undefined, Res)).
+
+post_with_string_content_type_test() ->
+    ContentType = "application/foo",
+    meck:new(httpc),
+    meck:expect(httpc, request, fun(post, {_, _, Type, _}, _, []) when Type == ContentType ->
+                                        {ok, {{a,b,c},d,e}};
+                                   (_, {_ , _, _, _}, _, _) ->
+                                        {error, bad_type}
+                                end),
+    URL = "http:localhost:8888/index.html",
+    Headers = [{"content-type", ContentType}],
+    Body = <<"{\"name\":\"value\"}">>,
+    ?assertMatch(#etest_http_res{}, etest_http:perform_request(post, URL, Headers, [], Body)),
+    meck:unload(httpc).
+
+post_with_binary_content_type_test() ->
+    ContentType = "application/foo",
+    meck:new(httpc),
+    meck:expect(httpc, request, fun(post, {_, _, Type, _}, _, []) when Type == ContentType ->
+                                        {ok, {{a,b,c},d,e}};
+                                   (_, _, _, _) ->
+                                        {error, bad_type}
+                                end),
+    URL = "http:localhost:8888/index.html",
+    Headers = [{<<"content-type">>, ContentType}],
+    Body = <<"{\"name\":\"value\"}">>,
+    ?assertMatch(#etest_http_res{}, etest_http:perform_request(post, URL, Headers, [], Body)),
+    meck:unload(httpc).
+    
+    


### PR DESCRIPTION
I've forked etest_http to add something that wasn't working. The scenario is when using ?perform_post macro. Basically you couldn't specify correctly 'content-type' provided in the body. It was being passed as "" to httpc regardless what you would send on the Headers. 

httpc erlang HTTP client takes the content-type as string as the third element of the tuple within the Request. In your 'master', it's always passed as empty string. My fix let the user provide the 'content-type' value as part of the proplists Headers (3rd argument of `etest_http:perform_request/5`. 
